### PR TITLE
Fix: Add missing Google Analytics script tag

### DIFF
--- a/_includes/head.liquid
+++ b/_includes/head.liquid
@@ -69,6 +69,10 @@
 <link rel="stylesheet" href="{{ '/assets/css/main.css' | relative_url | bust_css_cache }}">
 <link rel="canonical" href="{{ page.url | replace:'index.html','' | absolute_url }}">
 
+{% if site.enable_google_analytics and site.google_analytics %}
+<script async src="https://www.googletagmanager.com/gtag/js?id={{ site.google_analytics }}"></script>
+{% endif %}
+
 <!-- Dark Mode -->
 <script src="{{ '/assets/js/theme.js' | relative_url | bust_file_cache }}"></script>
 {% if site.enable_darkmode %}


### PR DESCRIPTION
The Google Analytics ID was correctly configured, but the main gtag.js script was not being loaded. This commit adds the necessary script tag to `_includes/head.liquid` to load the gtag.js script.

The script is added conditionally, only when `site.enable_google_analytics` is true and `site.google_analytics` is defined.